### PR TITLE
Correct spelling of systemd

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -5,7 +5,7 @@ Parca is a continuous profiling project. Continuous profiling is the act of taki
 The Parca project houses two main components:
 
 * Parca: The server that stores profiling data and allows it to be queried and analyzed over time.
-* Parca Agent: An eBPF based profiler, that can automatically discover targets to profile such as Kubernetes containers or SystemD units.
+* Parca Agent: An eBPF based profiler, that can automatically discover targets to profile such as Kubernetes containers or systemd units.
 
 ## Architecture
 

--- a/docs/parca-agent-design.md
+++ b/docs/parca-agent-design.md
@@ -16,7 +16,7 @@ From a high level it performs the following steps:
 
 ## Target Discovery
 
-The Parca Agent works by attaching the profiler to a [Linux cgroups](https://en.wikipedia.org/wiki/Cgroups), so the cgroups to attach to must first be discovered through some mechanism. Parca Agent currently has two primary mechanisms to discover cgroups: Kubernetes and SystemD. Besides the cgroup the target discovery also provides the labels to label a series of profiles being sent to the server.
+The Parca Agent works by attaching the profiler to a [Linux cgroups](https://en.wikipedia.org/wiki/Cgroups), so the cgroups to attach to must first be discovered through some mechanism. Parca Agent currently has two primary mechanisms to discover cgroups: Kubernetes and systemd. Besides the cgroup the target discovery also provides the labels to label a series of profiles being sent to the server.
 
 ### Kubernetes
 
@@ -26,11 +26,11 @@ To discover cgroups to profile in Kubernetes, Parca Agent first discovers all Po
 
 Labels provided by the Kubernetes discovery are: `node`, `namespace`, `pod`, `container` and `containerid`.
 
-### SystemD
+### systemd
 
-SystemD starts all services in a cgroup, and conveniently and consistently mounts the cgroup hierarchy. Unfortunately [`perf_event` is one of the few cgroups SystemD does not automatically manage](https://systemd.io/CGROUP_DELEGATION/#controller-support). This means the `perf_event` cgroup needs to be separately managed by Parca Agent. It will replicate the cgroup hierarchy under `system.slice`, into `perf_event` and sync the `cgroup.procs` once per second.
+systemd starts all services in a cgroup, and conveniently and consistently mounts the cgroup hierarchy. Unfortunately [`perf_event` is one of the few cgroups systemd does not automatically manage](https://systemd.io/CGROUP_DELEGATION/#controller-support). This means the `perf_event` cgroup needs to be separately managed by Parca Agent. It will replicate the cgroup hierarchy under `system.slice`, into `perf_event` and sync the `cgroup.procs` once per second.
 
-Labels provided by the SystemD discovery are: `node` and `systemd_unit`.
+Labels provided by the systemd discovery are: `node` and `systemd_unit`.
 
 ## Obtaining raw data
 

--- a/docs/parca-agent.md
+++ b/docs/parca-agent.md
@@ -7,14 +7,14 @@ The collected data can be viewed locally via HTTP endpoints and optionally be co
 It discovers targets to profile through:
 
 * Kubernetes: Discovering containers on the Kubernetes node the Parca agent is running on.
-* SystemD: Discovering SystemD units on the node the Parca agent is running on.
+* systemd: Discovering systemd units on the node the Parca agent is running on.
 
-Target discovery mechanisms can be combined, so that both SystemD units as well as Kubernetes containers are discovered and automatically profiled.
+Target discovery mechanisms can be combined, so that both systemd units as well as Kubernetes containers are discovered and automatically profiled.
 
 ## Requirements
 
 * Linux Kernel version 4.18+
-* A source of targets to discover from: Kubernetes or SystemD.
+* A source of targets to discover from: Kubernetes or systemd.
 
 ## Supported Profiles
 
@@ -30,7 +30,7 @@ Runtime specific information such as Goroutines, require explicit instrumentatio
 You can find a tutorial for each of the target discovery mechanisms below (each of these also contain a Parca server setup):
 
 * [Parca On Kubernetes](/docs/kubernetes) (if you are using [OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift) refer to the separate [Parca On OpenShift](/docs/openshift) documentation)
-* [SystemD Unit Profiling](/docs/systemd)
+* [systemd Unit Profiling](/docs/systemd)
 
 ## Troubleshooting
 

--- a/docs/parca.md
+++ b/docs/parca.md
@@ -5,4 +5,4 @@ Parca is a continuous profiling project. Continuous profiling is the act of taki
 The Parca project houses two main components:
 
 * Parca: The server that stores profiling data and allows it to be queried ana analyzed over time.
-* Parca Agent: An eBPF based profiler, that can automatically discover targets to profile such as Kubernetes containers or SystemD units.
+* Parca Agent: An eBPF based profiler, that can automatically discover targets to profile such as Kubernetes containers or systemd units.

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -1,2 +1,2 @@
-# SystemD Unit Profiling
+# systemd Unit Profiling
 

--- a/src/components/HomepageFeatures.js
+++ b/src/components/HomepageFeatures.js
@@ -17,7 +17,7 @@ const FeatureList = [
     image: <img className={styles.featureImage} src={require('@site/static/img/ebpf.png').default} />,
     description: (
       <>
-          A single profiler, using eBPF, automatically discovering targets from Kubernetes or SystemD across the entire infrastructure with very low overhead. Supports C, C++, Rust, Go, and more!
+          A single profiler, using eBPF, automatically discovering targets from Kubernetes or systemd across the entire infrastructure with very low overhead. Supports C, C++, Rust, Go, and more!
       </>
     ),
   },


### PR DESCRIPTION
As per various sources, it's spelled _systemd_ all lower case.

https://en.wikipedia.org/wiki/Systemd
https://github.com/systemd/systemd
https://systemd.io/