### PR TITLE
docs: fix single-file tar commands

### DIFF
--- a/docs/agent-binary.mdx
+++ b/docs/agent-binary.mdx
@@ -8,7 +8,7 @@ You can download the latest agent binary release for your architecture from our 
 <WithVersions language="bash">
   { versions =>
     <CodeBlock className="language-bash">
-      curl -sL https://github.com/parca-dev/parca-agent/releases/download/{versions.agent}/parca-agent_{versions.agent.substring(1)}_`uname -s`_`uname -m`.tar.gz | tar xvfz ./parca-agent
+      curl -sL https://github.com/parca-dev/parca-agent/releases/download/{versions.agent}/parca-agent_{versions.agent.substring(1)}_`uname -s`_`uname -m`.tar.gz | tar xvfz - parca-agent
     </CodeBlock>
   }
 </WithVersions>

--- a/docs/binary.mdx
+++ b/docs/binary.mdx
@@ -8,7 +8,7 @@ You can download the latest binary release for your architecture from our [relea
 <WithVersions language="bash">
   { versions =>
     <CodeBlock className="language-bash">
-      curl -sL https://github.com/parca-dev/parca/releases/download/{versions.server}/parca_{versions.server.substring(1)}_`uname -s`_`uname -m`.tar.gz | tar xvfz ./parca
+      curl -sL https://github.com/parca-dev/parca/releases/download/{versions.server}/parca_{versions.server.substring(1)}_`uname -s`_`uname -m`.tar.gz | tar xvfz - parca
     </CodeBlock>
   }
 </WithVersions>

--- a/docs/parca-agent-debuginfo-cli.mdx
+++ b/docs/parca-agent-debuginfo-cli.mdx
@@ -14,7 +14,7 @@ You can download the latest debug-info` binary release for your architecture fro
 <WithVersions language="bash">
   { versions =>
     <CodeBlock className="language-bash">
-      curl -sL https://github.com/parca-dev/parca-agent/releases/download/{versions.agent}/parca-agent_{versions.agent.substring(1)}_`uname -s`_`uname -m`.tar.gz | tar xvfz ./parca-debug-info
+      curl -sL https://github.com/parca-dev/parca-agent/releases/download/{versions.agent}/parca-agent_{versions.agent.substring(1)}_`uname -s`_`uname -m`.tar.gz | tar xvfz - parca-debug-info
     </CodeBlock>
   }
 </WithVersions>


### PR DESCRIPTION
This fixes up the single-file tar commands for me on both macOS and Ubuntu.