### PR TITLE
Update systemd example scrape_interval to 2s

### DIFF
--- a/docs/systemd.mdx
+++ b/docs/systemd.mdx
@@ -59,7 +59,7 @@ debug_info:
 
 scrape_configs:
   - job_name: "default"
-    scrape_interval: "1s"
+    scrape_interval: "2s"
     static_configs:
       - targets: ["127.0.0.1:7070"]
 ```


### PR DESCRIPTION
2s is the minimum that parca will accept, otherwise the service won't start