### PR TITLE
Fix incorrect autocomplete image path

### DIFF
--- a/docs/querying-parca.mdx
+++ b/docs/querying-parca.mdx
@@ -4,7 +4,11 @@ import BrowserWindow from '@site/src/components/BrowserWindow';
 
 Parca features a simple label-selector based query language, which is used to select the dimensions to be included in a query. The Parca web UI implements autocompletion to make this as easy as possible for newcomers.
 
-<img src="/img/tutorial/autocomplete.png" alt="Autocomplete" width="600" />
+<BrowserWindow>
+
+![Autocomplete](../static/img/tutorial/autocomplete.png)
+
+</BrowserWindow>
 
 ## Single point in time
 


### PR DESCRIPTION
[The 'Querying Parca' page](https://www.parca.dev/docs/querying-parca) doesn't display the autocomplete image currently.

**Before:**
![Before](https://user-images.githubusercontent.com/69148722/174112890-17f1ce9f-79d3-4ddd-aa68-73446797025a.png)

**After:**
![After](https://user-images.githubusercontent.com/69148722/174112930-092f7f0e-a452-4c88-8552-cfdac3645fb2.png)
