### PR TITLE
fix(ingestion): removing katacoda link

### DIFF
--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -10,7 +10,6 @@ The collected data can be [sent to a Parca server](https://buf.build/parca-dev/p
 
 ### Guides
 
-* [Getting started with Parca Scraping on Kubernetes](https://www.katacoda.com/parca/scenarios/scraping)
 * [Parca On Kubernetes](/docs/kubernetes) (if you are using [OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift) refer to the separate [Parca On OpenShift](/docs/openshift) documentation)
 * [systemd Unit Profiling with Parca Agent](/docs/systemd)
 


### PR DESCRIPTION
katacoda was taken offline by o'reilly and paywalled, hence this isn't an option to get started anymore and the link is to be removed as agreed in #178 

This fixes #178 