### PR TITLE
Update yaml file examples for 0.14

### DIFF
--- a/docs/binary.mdx
+++ b/docs/binary.mdx
@@ -25,12 +25,8 @@ We also produce Docker images that can be pulled:
 We provide an example configuration file that you can use to get Parca running, and the scrape configuration section should look familiar to anyone familiar with Prometheus.
 
 ```yaml
-debug_info:
+object_storage:
   bucket:
-    type: "FILESYSTEM"
-    config:
-      directory: "./tmp"
-  cache:
     type: "FILESYSTEM"
     config:
       directory: "./tmp"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,12 +5,8 @@ Parca obtains configuration information via a YAML file.
 The overall structure of a config file for Parca is as follows:
 
 ```yaml
-debug_info:
+object_storage:
   bucket:
-    type: "FILESYSTEM"
-    config:
-      directory: "./tmp"
-  cache:
     type: "FILESYSTEM"
     config:
       directory: "./tmp"

--- a/docs/systemd.mdx
+++ b/docs/systemd.mdx
@@ -47,12 +47,8 @@ adduser --system --no-create-home --group parca
 Parca runs with an example configuration file by default, that makes Parca to scrape itself.
 
 ```yaml
-debug_info:
+object_storage:
   bucket:
-    type: "FILESYSTEM"
-    config:
-      directory: "/tmp"
-  cache:
     type: "FILESYSTEM"
     config:
       directory: "/tmp"


### PR DESCRIPTION
Since https://github.com/parca-dev/parca/pull/1403 the syntax here doesn't work, so align with the new parca.yaml from the main repo

Fixes: #199