### PR TITLE
Do not quote config path

### DIFF
--- a/docs/kubernetes.mdx
+++ b/docs/kubernetes.mdx
@@ -230,7 +230,7 @@ template:
       - --remote-store-address=parca.parca.svc.cluster.local:7070
       - --remote-store-insecure
       - --remote-store-insecure-skip-verify
-+     - --config-path="/etc/parca-agent.yaml"
++     - --config-path=/etc/parca-agent.yaml
       - --temp-dir=/tmp
 ...
 ```

--- a/docs/openshift.mdx
+++ b/docs/openshift.mdx
@@ -229,7 +229,7 @@ template:
       - --remote-store-address=parca.parca.svc.cluster.local:7070
       - --remote-store-insecure
       - --remote-store-insecure-skip-verify
-+     - --config-path="/etc/parca-agent.yaml"
++     - --config-path=/etc/parca-agent.yaml
       - --temp-dir=/tmp
 ...
 ```


### PR DESCRIPTION
Quoting the file path causes Parca Agent to be unable to start. I didn't copy the error message exactly but I was getting something like `file or dir does not exist \"/etc/parca/parca-agent.yaml\"` The escaping of the file path is what made me wonder whether it was being passed with the quotes in tact. 