### PR TITLE
fix: scrape timeout must be greater than the interval

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,7 +21,7 @@ scrape_configs:
     # How frequently to scrape the targets of this scrape config.
     scrape_interval: "30s"
     # Timeout for scraping targets of this config.
-    scrape_timeout: "5s"
+    scrape_timeout: "40s"
     # URL scheme with which to fetch metrics from targets.
     scheme: https
     # Config for adding custom scrape endpoints.


### PR DESCRIPTION
to adapt to changes made in https://github.com/parca-dev/parca/pull/2220 😄 

I am wondering if it makes sense to add that the `scrape_interval` will be used for `/profile?seconds=<scrape_interval>`? AFAIK its not used for other types of profiles.