### PR TITLE
Fix Example for Scrape Interval and Timeout

### DIFF
--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -33,7 +33,7 @@ Pprof client libraries exist for various languages:
 
 ## Combining Push and Pull based Ingestion
 
-Deploy the Parca Agent as described above. Additionally collecting profiles in [pprof](https://github.com/google/pprof) format from HTTP endpoints. 
+Deploy the Parca Agent as described above. Additionally collecting profiles in [pprof](https://github.com/google/pprof) format from HTTP endpoints.
 If both are deployed the CPU profiles would be collected twice. Once by the Parca Agent and once by the Parca scraping the application's HTTP endpoints.
 
 To disable cpu profiling collections change the configuration:
@@ -55,13 +55,13 @@ scrape_configs:
 
 Additionally, any [`perf`](https://perf.wiki.kernel.org/index.php/Main_Page) profile can be converted to pprof using [`perf_data_converter`](https://github.com/google/perf_data_converter), so even programs that do not have native support for pprof can benefit from continuous profiling with Parca. We do, however, recommend to use native instrumentation when possible, as it allows language and runtime specific nuances to be encoded in the respective libraries.
 
-Once there is an HTTP endpoint that serves profiles in pprof format, all that needs to be done is to configure Parca to collect the profile in a regular interval. Configuration can be set in [`parca/parca.yaml`](https://github.com/parca-dev/parca/blob/main/parca.yaml). For `fgprof` profile collection, for example, the scrape configuration in the `parca.yaml` file could be set in the following manner: 
+Once there is an HTTP endpoint that serves profiles in pprof format, all that needs to be done is to configure Parca to collect the profile in a regular interval. Configuration can be set in [`parca/parca.yaml`](https://github.com/parca-dev/parca/blob/main/parca.yaml). For `fgprof` profile collection, for example, the scrape configuration in the `parca.yaml` file could be set in the following manner:
 
 ```diff
 scrape_configs:
   - job_name: "default"
-    scrape_interval: "60s"
-    scrape_timeout: "45s"
+    scrape_interval: "45s"
+    scrape_timeout: "60s"
     static_configs:
       - targets: [ '127.0.0.1:7070' ]
 +   profiling_config:


### PR DESCRIPTION
This PR fixes the example [Ingestion](https://www.parca.dev/docs/ingestion) documentation, where the `scrape_interval` was larger than the `scrape_timeout` which isn't a valid configuration.

See:

- https://github.com/parca-dev/parca/issues/3436
- https://github.com/parca-dev/parca/pull/4140