### PR TITLE
docs: add link to snaps tutorial from quickstart

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -150,5 +150,10 @@ minikube start --driver=virtualbox
     sudo snap start parca
     ```
 
+<br />
+
+:::danger [Parca from Snaps - Tutorial 5min ⏱️](/docs/agent-server-snap-services)
+:::
+
 </TabItem>
 </Tabs>


### PR DESCRIPTION
Minor change to link tutorial from the quickstart for snaps.