### PR TITLE
Update systemd.mdx to remove tip to broken Katacoda link

### DIFF
--- a/docs/systemd.mdx
+++ b/docs/systemd.mdx
@@ -6,12 +6,6 @@ import BrowserWindow from '@site/src/components/BrowserWindow';
 
 ## Setting up Parca
 
-:::tip
-
-You can find interactive version of this tutorial at our Katacoda account. Check it out [here](https://www.katacoda.com/parca/scenarios/systemd).
-
-:::
-
 You can download the latest binary release for your architecture from our [releases page](https://github.com/parca-dev/parca/releases).
 <WithVersions language="bash">
   { versions =>


### PR DESCRIPTION
The tip contains a link to Katacoda, which is now closed to the public.