### PR TITLE
Update quickstart.mdx

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -77,7 +77,7 @@ Run Parca Agent (requires privileged more) and access the Web UI on port 7071 (a
 <WithVersions language="bash">
     { versions =>
         <CodeBlock className="language-bash">
-        docker run --rm -it --privileged --pid host -d -p 7071:7071 -v /run:/run -v /boot:/boot -v /data:/data -v /lib/modules:/lib/modules -v /sys/kernel/debug:/sys/kernel/debug -v /sys/fs/cgroup:/sys/fs/cgroup -v /sys/fs/bpf:/sys/fs/bpf -v /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket ghcr.io/parca-dev/parca-agent:{versions.agent} /bin/parca-agent  --remote-store-address=<parca-container-ip>:7070 --remote-store-insecure
+        docker run --rm -it --privileged --pid host -d -p 7071:7071 -v /run:/run -v /boot:/boot -v /data:/data -v /lib/modules:/lib/modules -v /sys/kernel/debug:/sys/kernel/debug -v /sys/fs/cgroup:/sys/fs/cgroup -v /sys/fs/bpf:/sys/fs/bpf -v /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket ghcr.io/parca-dev/parca-agent:{versions.agent} /bin/parca-agent  --remote-store-address=parca-container-ip:7070 --remote-store-insecure
         </CodeBlock>
     }
 </WithVersions>

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -73,11 +73,11 @@ Run Parca and access the Web UI on port 7070
 
 **Agent**
 
-Run Parca Agent (requires privileged more) and access the Web UI on port 7071 (assumes Parca is running on localhost:7070)
+Run Parca Agent (requires privileged more) and access the Web UI on port 7071 (assumes Parca is running as a container on the same host. Replace IP for "--remote-store-address")
 <WithVersions language="bash">
     { versions =>
         <CodeBlock className="language-bash">
-        docker run --rm --privileged --pid host ghcr.io/parca-dev/parca-agent:{versions.agent} /bin/parca-agent --node=docker-test --remote-store-address=localhost:7070 --remote-store-insecure
+        docker run --rm -it --privileged --pid host -d -p 7071:7071 -v /run:/run -v /boot:/boot -v /data:/data -v /lib/modules:/lib/modules -v /sys/kernel/debug:/sys/kernel/debug -v /sys/fs/cgroup:/sys/fs/cgroup -v /sys/fs/bpf:/sys/fs/bpf -v /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket ghcr.io/parca-dev/parca-agent:{versions.agent} /bin/parca-agent  --remote-store-address=<parca-container-ip>:7070 --remote-store-insecure
         </CodeBlock>
     }
 </WithVersions>


### PR DESCRIPTION
Modify the command to run the parca-agent as a docker container in the quick-start documentation because the current one doesn't work.