### PR TITLE
Quickstart: Fix 'privileged mode' typo

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -73,7 +73,7 @@ Run Parca and access the Web UI on port 7070
 
 **Agent**
 
-Run Parca Agent (requires privileged more) and access the Web UI on port 7071 (assumes Parca is running as a container on the same host. Replace IP for "--remote-store-address")
+Run Parca Agent (requires privileged mode) and access the Web UI on port 7071 (assumes Parca is running as a container on the same host. Replace IP for "--remote-store-address")
 <WithVersions language="bash">
     { versions =>
         <CodeBlock className="language-bash">


### PR DESCRIPTION
Fixes small typo in the quickstart guide

~Edit: Also updates wordlist with (valid) exceptions from previous PR ([ci link](https://github.com/parca-dev/docs/actions/runs/8195193318/job/22412897207#step:4:57))~
Fixed in a separate PR