### PR TITLE
Update emeritus maintainers in governance.md 

### DIFF
--- a/docs/governance.md
+++ b/docs/governance.md
@@ -78,6 +78,8 @@ The current team members are:
 _Please note that Parca had received significant contributions from a number of unlisted individuals before this
 governance document, and thus formal team membership, was created._
 
+
+
 ### Maintainers
 
 Maintainers lead one or more project(s) or parts thereof and serve as a point of conflict resolution amongst the
@@ -97,6 +99,10 @@ encouraged to propose another team member to take over the project.
 
 A project may have multiple maintainers, as long as the responsibilities are clearly agreed upon between them.
 This includes coordinating who handles which issues and pull requests.
+
+#### Emeritus Maintainers
+* Javier Honduvilla Coto
+* Vaishali Thakkar
 
 ### Technical decisions
 

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -23,6 +23,7 @@ bcc
 bd
 blog
 BPF
+bpf
 bpftool
 Brancyzk
 brancz
@@ -67,6 +68,7 @@ datacenter
 Datasource
 datasource
 db
+dbus
 de
 DebugInfo
 Debuginfo
@@ -114,6 +116,7 @@ FlameGraphs
 flamegraphs
 frontend
 FrostDB
+fs
 func
 ghcr
 ghrc
@@ -144,6 +147,7 @@ inlined
 integrations
 interactable
 io
+ip
 iterateLong
 iterateShort
 Jaeger
@@ -151,8 +155,8 @@ JIT
 jit
 jitdump
 js
-justtrustme
 JSON
+justtrustme
 JVM
 KASLR
 Katacoda
@@ -313,6 +317,7 @@ Supermajority
 supermajority
 symbolizable
 symbolizer
+sys
 syslog
 SyslogIdentifier
 System-wide


### PR DESCRIPTION
It seems we've missed updating this list after https://github.com/parca-dev/parca-agent/pull/1875 was merged. Also, the other emeritus maintainers are added to the list.