### PR TITLE
Fix Parca Agent binary install steps

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -43,14 +43,15 @@ import CodeBlock from '@theme/CodeBlock';
 <WithVersions language="bash">
     { versions =>
         <CodeBlock className="language-bash">
-        curl -sL https://github.com/parca-dev/parca-agent/releases/download/{versions.agent}/parca-agent_{versions.agent.substring(1)}_`uname -s`_`uname -m`.tar.gz | tar xvfz -
+        curl -sL https://github.com/parca-dev/parca-agent/releases/download/{versions.agent}/parca-agent_{versions.agent.substring(1)}_`uname -s`_`uname -m`
+        chmod +x ./parca-agent*
         </CodeBlock>
     }
 </WithVersions>
 
 2. Run Parca Agent and access the Web UI on port 7071 (assumes Parca is running on localhost:7070)
     ```bash
-    ./parca-agent --node=test --remote-store-address=localhost:7070 --remote-store-insecure
+    sudo ./parca-agent* --node=test --remote-store-address=localhost:7070 --remote-store-insecure
     ```
 
 <br />


### PR DESCRIPTION
This is exactly what I had to do now to get it working on a freshly installed Pop!_OS

---

Unfortunately, I've hit another bug, but will file that separately:
<img width="2876" alt="image" src="https://github.com/parca-dev/docs/assets/3342/b2889354-1b52-4b5b-930a-4604faa7d0d1">
