### PR TITLE
Quickstart: Fix docker command for agent

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -77,7 +77,7 @@ Run Parca Agent (requires privileged mode) and access the Web UI on port 7071 (a
 <WithVersions language="bash">
     { versions =>
         <CodeBlock className="language-bash">
-        docker run --rm -it --privileged --pid host -d -p 7071:7071 -v /run:/run -v /boot:/boot -v /data:/data -v /lib/modules:/lib/modules -v /sys/kernel/debug:/sys/kernel/debug -v /sys/fs/cgroup:/sys/fs/cgroup -v /sys/fs/bpf:/sys/fs/bpf -v /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket ghcr.io/parca-dev/parca-agent:{versions.agent} /bin/parca-agent  --remote-store-address=parca-container-ip:7070 --remote-store-insecure
+        docker run --rm -it --privileged --pid host -p 7071:7071 -v /run:/run -v /boot:/boot -v /lib/modules:/lib/modules -v /sys/kernel/debug:/sys/kernel/debug -v /sys/fs/cgroup:/sys/fs/cgroup -v /sys/fs/bpf:/sys/fs/bpf -v /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket ghcr.io/parca-dev/parca-agent:{versions.agent} /bin/parca-agent  --remote-store-address=parca-container-ip:7070 --remote-store-insecure
         </CodeBlock>
     }
 </WithVersions>


### PR DESCRIPTION
The agent doesn't have a data directory.