### PR TITLE
Fix language support hyperlink

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -7,7 +7,7 @@ Frequently asked questions. If anything is unclear or not covered in the documen
 
 ## What languages are supported?
 
-Infrastructure-wide always-on automatic profiling with Parca Agent currently supports languages like C, C++, Rust, Go (with extended support for Go), Ruby, Node.js, Python, Java, Rust, JVM, .NET, Perl, and PHP and many more. The list is continuously growing. For more details, please refer to the [Language Support](https://www.parca.dev/docs/language-support) page.
+Infrastructure-wide always-on automatic profiling with Parca Agent currently supports languages like C, C++, Rust, Go (with extended support for Go), Ruby, Node.js, Python, Java, Rust, JVM, .NET, Perl, and PHP and many more. The list is continuously growing. For more details, please refer to the [Language Support](https://www.parca.dev/docs/parca-agent-language-support) page.
 
 Parca itself supports any [pprof](https://github.com/google/pprof) formatted profile. Any library or implementation that outputs valid pprof profiles is supported by Parca. More details about pprof client libraries for various languages can be found [here](https://www.parca.dev/docs/ingestion#pull-based).
 


### PR DESCRIPTION
Previous hyperlink returns a `404`.