### PR TITLE
fix: release of parca-agent is as binary, not archive

### DIFF
--- a/docs/agent-binary.mdx
+++ b/docs/agent-binary.mdx
@@ -8,7 +8,8 @@ You can download the latest agent binary release for your architecture from our 
 <WithVersions language="bash">
   { versions =>
     <CodeBlock className="language-bash">
-      curl -sL https://github.com/parca-dev/parca-agent/releases/download/{versions.agent}/parca-agent_{versions.agent.substring(1)}_`uname -s`_`uname -m`.tar.gz | tar xvfz - parca-agent
+      curl -sL https://github.com/parca-dev/parca-agent/releases/download/{versions.agent}/parca-agent_{versions.agent.substring(1)}_`uname -s`_`uname -m` -o parca-agent && \
+      chmod +x parca-agent
     </CodeBlock>
   }
 </WithVersions>


### PR DESCRIPTION
Fixes #441 