### PR TITLE
chore: fix ghcr.io typo

### DIFF
--- a/docs/parca-agent-security.md
+++ b/docs/parca-agent-security.md
@@ -35,7 +35,7 @@ Read more on CO-RE and libbpf:
 ## Sigstore
 
 We provide signatures of release artifacts via [sigstore](https://sigstore.dev/). See [parca-dev/parca-agent#16](https://github.com/parca-dev/parca-agent/issues/16) for more details.
-And also see the default registry for the signatures: [ghrc.io/parca-dev/parca-agent](https://github.com/parca-dev/parca-agent/pkgs/container/parca-agent)
+And also see the default registry for the signatures: [ghcr.io/parca-dev/parca-agent](https://github.com/parca-dev/parca-agent/pkgs/container/parca-agent)
 
 ## Automated code scanning
 


### PR DESCRIPTION
After reading through "[ghrc.io Appears to be Malicious](https://bmitch.net/blog/2025-08-22-ghrc-appears-malicious/)", I found this typo, so I thought it might be nice to fix it 🙂 